### PR TITLE
compile in pid file

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -81,7 +81,8 @@
          [
           {post_start,
            [
-            {wait_for_process, blockchain_worker}
+            {wait_for_process, blockchain_worker},
+            {pid, "miner.pid"}
            ]}
          ]},
         {extended_start_script, true},


### PR DESCRIPTION
for the folks out there wanting to run validators outside of docker it would be very useful to have a pid file in place. This will allow us to utilize  tools like sysrc more effectively and allow us to opensource upstart scripts.